### PR TITLE
Make use of environment variable for BASE_URL

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -6,13 +6,13 @@ const request = require('request');
 const url = require('url');
 // Add your routes here - above the module.exports line
 
-const BASE_URL = process.env.BASE_URL
+const API_URL = process.env.API_URL
 
 
 router.get('/browse/:topicSlug', function (req, res) {
   topicSlug = req.params.topicSlug
 
-  request(BASE_URL + 'browse/' + topicSlug, { json: true }, (error, result, body) => {
+  request(API_URL + 'browse/' + topicSlug, { json: true }, (error, result, body) => {
     body.topicSlug = topicSlug;
     body.organisations = body.organisations.slice(0,5);
     body.latest_news = body.latest_news.slice(0,3);
@@ -31,8 +31,8 @@ router.get('/browse/:topicSlug/:subTopicSlug', function (req, res) {
   topicSlug = req.params.topicSlug
   subTopicSlug = req.params.subTopicSlug
 
-  request(BASE_URL + 'browse/' + topicSlug + '/' + subTopicSlug, { json: true }, (error, result, body) => {
-    request(BASE_URL + 'browse/' + topicSlug, { json: true }, (error, result, bodyTopic) => {
+  request(API_URL + 'browse/' + topicSlug + '/' + subTopicSlug, { json: true }, (error, result, body) => {
+    request(API_URL + 'browse/' + topicSlug, { json: true }, (error, result, bodyTopic) => {
       body.topicSlug = topicSlug;
       body.organisations = body.organisations.slice(0,5);
       body.latest_news = body.latest_news.slice(0,3);

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,8 +6,7 @@ const request = require('request');
 const url = require('url');
 // Add your routes here - above the module.exports line
 
-const BASE_URL = 'https://govuk-explore-api-prototype.herokuapp.com/'
-//const BASE_URL = 'http://localhost:3050/'
+const BASE_URL = process.env.BASE_URL
 
 
 router.get('/browse/:topicSlug', function (req, res) {


### PR DESCRIPTION
Prior to this proposed change we have to remember to switch to the correct `BASE_URL` before pushing the code up to Heroku. If the BASE_URL is set for localhost then heroku will thow an error.

I think using environment variables as suggested by Max would be a good idea, so I propose this alteration 

- N.B. in .env file need to set API_URL=http://localhost:3050/
        on heroku (one time only activity) need to set BASE_URL to be https://govuk-explore-api-prototype.herokuapp.com/